### PR TITLE
Code clean up and some additional changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ angular.module('webApp', ['angular-zipcode-filter']);
 You can use it like any other AngularJS filter:
 
 ```html
-<p>{{ 028861617 | zipcode }}</p>
+<p>{{ 928861617 | zipcode }}</p>
 ```
 
 The output will be:
 ```html
-<p>02886-1617</p>
+<p>92886-1617</p>
 ```
 
 ## Testing

--- a/test/zipcode.js
+++ b/test/zipcode.js
@@ -11,7 +11,7 @@ describe('Filter: zipcode', function () {
     zipcode = $filter('zipcode');
   }));
 
-  it('adds a dash after the 5th chacater of a 9-digit zip code', function () {
+  it('adds a dash after the 5th character of a 9-digit zip code', function () {
     var input = 981222735;
     expect(zipcode(input)).toBe('98122-2735');
   });
@@ -25,8 +25,11 @@ describe('Filter: zipcode', function () {
     expect(zipcode(1234567890)).toBe(1234567890);
   });
 
-  it('does nothing if input is invalid', function () {
+  it('does nothing if input is undefined', function () {
     expect(zipcode()).toBe();
   });
 
+  it('does nothing if input is null', function () {
+    expect(zipcode(null)).toBe(null);
+  });
 });

--- a/zipcode.js
+++ b/zipcode.js
@@ -6,6 +6,8 @@
  * @author Felippe Nardi <felippe.ng-zipcode@nardi.me>
  *
  * @param {number} input the number to be formatted.
+ *
+ * @return {string|number}
  */
 angular.module('angular-zipcode-filter',[])
   .filter('zipcode', function () {
@@ -13,12 +15,11 @@ angular.module('angular-zipcode-filter',[])
       if (!input) {
         return input;
       }
-      if (input.toString().length === 9) {
-        return input.toString().slice(0, 5) + "-" + input.toString().slice(5);
-      } else if (input.toString().length === 5) {
-        return input.toString();
-      } else {
-        return input;
+      if (String(input).length === 9) {
+        return String(input).slice(0, 5) + "-" + String(input).slice(5);
+      } else if (String(input).length === 5) {
+        return String(input);
       }
+      return input;
     };
   });

--- a/zipcode.min.js
+++ b/zipcode.min.js
@@ -1,1 +1,1 @@
-"use strict";angular.module("angular-zipcode-filter",[]).filter("zipcode",function(){return function(a){return a?9===a.toString().length?a.toString().slice(0,5)+"-"+a.toString().slice(5):5===a.toString().length?a.toString():a:a}});
+"use strict";angular.module("angular-zipcode-filter",[]).filter("zipcode",function(){return function(a){return a?9===String(a).length?String(a).slice(0,5)+"-"+String(a).slice(5):5===String(a).length?String(a):a:a}});


### PR DESCRIPTION
- Added test for if input is null
- Changed toString() to String (toString() fails on null value)
- Updated readme to a better example
- Spelling fix
- Added return value to description
- else statement not needed if everything else returns

Also, just a heads up.  All Zip Codes should have to be a string.  Numbers that start with 0 (like in the readme) that are converted to string will have the 0 stripped off the front of them.

https://jsfiddle.net/rhcgmv9L/

If it's forced as a string, the Angular filter can be even stripped of more code.  The tests passed because there wasn't a test where the number started with 0.  A test fails with leading zero
